### PR TITLE
Update package.json with types export

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/types/index.d.ts",
   "type": "module",
   "exports": {
+    "types": "./dist/types/index.d.ts",
     "import": "./dist/esm/index.js",
     "require": "./dist/cjs/index.js",
     "default": "./dist/esm/index.js"


### PR DESCRIPTION
Newer typescript versions refuse to use the types unless explicitly mapped in package.json:

>Could not find a declaration file for module 'flac-tagger'. '/PATH_TO_REPO/node_modules/flac-tagger/dist/esm/index.js' implicitly has an 'any' type.
>  There are types at '/PATH_TO_REPO/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'flac-tagger' library may need to update its package.json or typings.

Adding to package.json to map the types file explicitly.